### PR TITLE
Update mlenc_blstm.py

### DIFF
--- a/mlenc/mlenc_blstm.py
+++ b/mlenc/mlenc_blstm.py
@@ -19,7 +19,6 @@ import torch
 import numpy as np
 import torch.nn as nn
 from torch.autograd import Variable
-from torch.utils.serialization import load_lua
 import mlenc_const as const
 
 


### PR DESCRIPTION
- remove load lua -> pytorch 1.0 does not support it. And since it is not used here...