### PR TITLE
Undefined names: import sys for access to sys.exit()

### DIFF
--- a/source/lib/indexing.py
+++ b/source/lib/indexing.py
@@ -16,6 +16,7 @@
 
 import faiss
 import os.path
+import sys
 import numpy as np
 
 

--- a/source/lib/text_processing.py
+++ b/source/lib/text_processing.py
@@ -16,6 +16,7 @@
 
 import os
 import pdb
+import sys
 import tempfile
 import numpy as np
 from subprocess import run, check_output, DEVNULL


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/facebookresearch/LASER on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./source/paraphrase.py:67:53: F821 undefined name 'n'
                  .format(stats.nbs, 0.0, sentences[n].replace('@@ ', '')))
                                                    ^
./source/lib/text_processing.py:239:9: F821 undefined name 'sys'
        sys.exit(1)
        ^
./source/lib/indexing.py:65:35: F821 undefined name 'args'
                          .format(args.langs[i1], args.langs[i2],
                                  ^
./source/lib/indexing.py:65:51: F821 undefined name 'args'
                          .format(args.langs[i1], args.langs[i2],
                                                  ^
./source/lib/indexing.py:130:13: F821 undefined name 'sys'
            sys.exit(1)
            ^
5     F821 undefined name 'args'
5
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
