### PR TITLE
Update fastBPE's compilation command

### DIFF
--- a/install_external_tools.sh
+++ b/install_external_tools.sh
@@ -106,7 +106,7 @@ InstallFastBPE () {
     mv fastBPE-master fastBPE
     cd fastBPE
     echo " - compiling"
-    g++ -std=c++11 -pthread -O3 fast.cc -o fast
+    g++ -std=c++11 -pthread -O3 fastBPE/main.cc -IfastBPE -o fast
     if [ $? -eq 1 ] ; then
       echo "ERROR: compilation failed, please install manually"; exit
     fi


### PR DESCRIPTION
The fastBPE library recently (2 days ago) got updated. Now the ``install_external_tools.sh`` bash script fails. So I updated the command in that file with the new one from [fastBPE's readme](https://github.com/glample/fastBPE/commit/8af0dae779f11d9385d021915dffa0b7d4303e63).