### PR TITLE
Option to install MeCab automatically (also on Docker) and fix MeCab encoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ be found in [6], together with an extensive experimental evaluation.
 * set the environment variable 'LASER' to the root of the installation, e.g.
   `export LASER="${HOME}/projects/laser"`
 * download encoders from Amazon s3 by `bash ./install_models.sh`
-* download third party software by `bash ./install_external_tools.sh`
+* download third party software by `bash ./install_external_tools.sh` (use `--install-mecab` argument to try the automatic installation of mecab)
 * download the data used in the example tasks (see description for each task)
 
 ## Applications

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN bash ./install_models.sh
 
 RUN conda install --name env -c pytorch faiss-cpu -y
 
-RUN bash ./install_external_tools.sh
+RUN bash ./install_external_tools.sh --install-mecab
 
 COPY ./decode.py $LASER/tasks/embed/decode.py
 

--- a/install_external_tools.sh
+++ b/install_external_tools.sh
@@ -133,7 +133,7 @@ InstallMecab () {
       mkdir mecab
       cd mecab-master/mecab
       echo " - installing code"
-      ./configure --prefix ${tools_ext}/mecab && make && make install 
+      ./configure --prefix ${tools_ext}/mecab --with-charset=utf8 && make && make install 
       if [ $? -q 1 ] ; then
         echo "ERROR: installation failed, please install manually"; exit
       fi
@@ -141,7 +141,7 @@ InstallMecab () {
     if [ ! -d mecab/lib/mecab/dic/ipadic ] ; then
       cd ${tools_ext}/mecab-master/mecab-ipadic
       echo " - installing dictionaries"
-      ./configure --prefix ${tools_ext}/mecab --with-mecab-config=${tools_ext}/mecab/bin/mecab-config \
+      ./configure --prefix ${tools_ext}/mecab --with-mecab-config=${tools_ext}/mecab/bin/mecab-config --with-charset=utf8 \
         && make && make install 
       if [ $? -eq 1 ] ; then
         echo "ERROR: compilation failed, please install manually"; exit

--- a/install_external_tools.sh
+++ b/install_external_tools.sh
@@ -124,7 +124,7 @@ InstallFastBPE () {
 
 InstallMecab () {
   cd ${tools_ext}
-  if [ ! -x mecab/mecab/bin/mecab ] ; then
+  if [ ! -x mecab/bin/mecab ] ; then
     echo " - download mecab from github"
     wget https://github.com/taku910/mecab/archive/master.zip
     unzip master.zip 
@@ -157,15 +157,29 @@ InstallMecab () {
 #
 ###################################################################
 
+for arg
+do
+  case "$arg" in
+    --install-mecab)
+    install_mecab=1
+    ;;
+  esac
+done
+
 echo "Installing external tools"
 
 InstallMosesTools
 InstallFastBPE
 
-#InstallMecab
-echo ""
-echo "automatic installation of the Japanese tokenizer mecab may be tricky"
-echo "Please install it manually from https://github.com/taku910/mecab"
-echo ""
-echo "The installation directory should be ${LASER}/tools-external/mecab"
-echo ""
+if [[ -n "$install_mecab" ]]; then
+  InstallMecab
+else
+  echo ""
+  echo "Automatic installation of the Japanese tokenizer mecab may be tricky"
+  echo ""
+  echo "Please use --install-mecab argument to try the automatic installation"
+  echo "or install it manually from https://github.com/taku910/mecab"
+  echo ""
+  echo "The installation directory should be ${LASER}/tools-external/mecab"
+  echo ""
+fi

--- a/install_external_tools.sh
+++ b/install_external_tools.sh
@@ -133,7 +133,7 @@ InstallMecab () {
       mkdir mecab
       cd mecab-master/mecab
       echo " - installing code"
-      ./configure --prefix ${tools_ext}/mecab --with-charset=utf8 && make && make install 
+      ./configure --prefix ${tools_ext}/mecab --enable-utf8-only && make && make install 
       if [ $? -q 1 ] ; then
         echo "ERROR: installation failed, please install manually"; exit
       fi


### PR DESCRIPTION
Hi @hoschwenk 

I'm the maintainer of [laserembeddings](https://github.com/yannvgn/laserembeddings/), a packaged version of LASER installable with `pip`.
During the generation of samples of sentence embeddings (used to make sure the results I get with my package are the same as computed here) I had troubles processing Japanese sentences.

I followed the installation instructions of MeCab but I had weird issues that seemed to be related to the encoding used by MeCab.

I also noticed that MeCab was not installed by default in the Docker version of LASER (there's no reason not to install it there by default I think).

**This PR in a nutshell:**
- [X] I added the `--install-mecab` option to `install_external_tools.sh` (disabled by default) to try the automatic installation of MeCab (which should work in many contexts)
- [X] Mecab is now installed by default on Docker
- [X] MeCab is now installed in UTF-8 (I followed this: https://github.com/facebookresearch/LASER/issues/54#issuecomment-486928359)
- [X] I fixed the line that checks if MeCab is already installed (so that it's not being re-installed when running `install_external_tools.sh` again)

This would hopefully solve #54 and #92

Last but not least: THANK YOU for releasing and open-sourcing LASER. It is SO helpful for us who have to work on multilingual contexts. ✨✨✨