### PR TITLE
Remove unused arguments and imports

### DIFF
--- a/docker/app.py
+++ b/docker/app.py
@@ -51,7 +51,6 @@ def vectorize():
                   str(tok_fname),
                   lang=lang,
                   romanize=True if lang == 'el' else False,
-                  lower_case=True,
                   gzip=False,
                   verbose=True,
                   over_write=False)

--- a/source/embed.py
+++ b/source/embed.py
@@ -370,7 +370,7 @@ if __name__ == '__main__':
                   tok_fname,
                   lang=args.token_lang,
                   romanize=True if args.token_lang == 'el' else False,
-                  lower_case=True, gzip=False,
+                  gzip=False,
                   verbose=args.verbose, over_write=False)
             ifname = tok_fname
 

--- a/source/lib/text_processing.py
+++ b/source/lib/text_processing.py
@@ -46,8 +46,7 @@ MECAB = LASER + '/tools-external/mecab'
 #
 ###############################################################################
 
-def TokenLine(line, lang='en', lower_case=True, romanize=False):
-    assert lower_case, 'lower case is needed by all the models'
+def TokenLine(line, lang='en', romanize=False):
     roman = lang if romanize else 'none'
     tok = check_output(
             REM_NON_PRINT_CHAR
@@ -70,9 +69,8 @@ def TokenLine(line, lang='en', lower_case=True, romanize=False):
 ###############################################################################
 
 def Token(inp_fname, out_fname, lang='en',
-          lower_case=True, romanize=False, descape=False,
+          romanize=False, descape=False,
           verbose=False, over_write=False, gzip=False):
-    assert lower_case, 'lower case is needed by all the models'
     assert not over_write, 'over-write is not yet implemented'
     if not os.path.isfile(out_fname):
         cat = 'zcat ' if gzip else 'cat '
@@ -110,7 +108,7 @@ def Token(inp_fname, out_fname, lang='en',
 #
 ###############################################################################
 
-def BPEfastLoad(line, bpe_codes):
+def BPEfastLoad(bpe_codes):
     bpe_vocab = bpe_codes.replace('fcodes', 'fvocab')
     return fastBPE.fastBPE(bpe_codes, bpe_vocab)
 

--- a/source/mine_bitexts.py
+++ b/source/mine_bitexts.py
@@ -28,8 +28,7 @@ LASER = os.environ['LASER']
 
 sys.path.append(LASER + '/source')
 sys.path.append(LASER + '/source/tools')
-from embed import SentenceEncoder, EncodeLoad, EncodeFile, EmbedLoad
-from text_processing import Token, BPEfastApply
+from embed import EmbedLoad
 
 
 ###############################################################################

--- a/source/paraphrase.py
+++ b/source/paraphrase.py
@@ -247,7 +247,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
               ifile,
               lang=args.token_lang,
               romanize=True if args.token_lang == 'el' else False,
-              lower_case=True, gzip=False,
+              gzip=False,
               verbose=args.verbose, over_write=False)
 
     if args.bpe_codes:

--- a/source/similarity_search.py
+++ b/source/similarity_search.py
@@ -92,7 +92,6 @@ for l in args.lang:
           os.path.join(args.base_dir, args.output + '.tok.' + l),
           lang=l,
           romanize=True if l == 'el' else False,
-          lower_case=True,
           verbose=args.verbose, over_write=False)
     BPEfastApply(os.path.join(args.base_dir, args.output + '.tok.' + l),
                  os.path.join(args.base_dir, args.output + '.bpe.' + l),

--- a/tasks/mldoc/mldoc.py
+++ b/tasks/mldoc/mldoc.py
@@ -82,7 +82,7 @@ for part in ('train1000', 'dev', 'test'):
               cfname + '.tok.' + lang,
               lang=lang,
               romanize=(True if lang == 'el' else False),
-              lower_case=True, gzip=False,
+              gzip=False,
               verbose=args.verbose, over_write=False)
         SplitLines(cfname + '.tok.' + lang,
                    cfname + '.split.' + lang,

--- a/tasks/xnli/xnli.py
+++ b/tasks/xnli/xnli.py
@@ -78,7 +78,7 @@ for lang in languages_train:
               cfname + 'tok.' + lang,
               lang=lang,
               romanize=True if lang=='el' else False,
-              lower_case=True, gzip=True,
+              gzip=True,
               verbose=args.verbose, over_write=False)
         BPEfastApply(cfname + 'tok.' + lang,
                      cfname + 'bpe.' + lang,
@@ -99,7 +99,7 @@ for corpus in ('xnli.dev', 'xnli.test'):
                   cfname + 'tok.' + lang,
                   lang=lang,
                   romanize=True if lang=='el' else False,
-                  lower_case=True, gzip=False,
+                  gzip=False,
                   verbose=args.verbose, over_write=False)
             BPEfastApply(cfname + 'tok.' + lang,
                          cfname + 'bpe.' + lang,


### PR DESCRIPTION
* Removed unused `lower_case` argument in `Token` and `TokenLine`
* Removed unused (and confusing) `line` argument in `BPEfastLoad`
* Removed unused imports in `mine_bitexts.py`