### PR TITLE
Exit from embed.sh with a non-zero exit code in case of error

### DIFF
--- a/tasks/embed/embed.sh
+++ b/tasks/embed/embed.sh
@@ -17,12 +17,12 @@
 
 if [ -z ${LASER+x} ] ; then
   echo "Please set the environment variable 'LASER'"
-  exit
+  exit 1
 fi
 
 if [ $# -ne 3 ] ; then
   echo "usage embed.sh input-file language output-file"
-  exit
+  exit 1
 fi
 
 ifile=$1


### PR DESCRIPTION
Otherwise, errors are silently hidden, making debugging harder than it could be.