### PR TITLE
Fixing some bugs so that dl_cc_matrix.py finalize runs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3
 
 MAINTAINER Gilles Bodart <gillesbodart@users.noreply.github.com>
 
-RUN conda create -n env python=3.6
+RUN conda create -n env python=3.7
 RUN echo "source activate env" > ~/.bashrc
 ENV PATH /opt/conda/envs/env/bin:$PATH
 
@@ -49,9 +49,31 @@ RUN bash ./install_external_tools.sh
 
 COPY ./decode.py $LASER/tasks/embed/decode.py
 
+# Dependencies for kenlm needed by cc_net
+RUN apt-get -qq -y install \
+	build-essential \
+	cmake \
+	libboost-system-dev \
+	libboost-thread-dev \
+	libboost-program-options-dev \
+	libboost-test-dev \
+	libeigen3-dev \
+	zlib1g-dev \
+	libbz2-dev \
+	liblzma-dev
+
+# Installing cc_net
+WORKDIR /
+
+RUN git clone https://github.com/facebookresearch/cc_net.git
+
+WORKDIR /cc_net
+
+RUN make install
 
 # Make port 80 available to the world outside this container
 WORKDIR /app
+
 
 RUN echo "Hello World" > test.txt
 

--- a/tasks/CCMatrix/fix_files.py
+++ b/tasks/CCMatrix/fix_files.py
@@ -1,0 +1,31 @@
+import argparse
+import gzip
+import re
+from shutil import copyfile
+import os
+
+def fix(filename):
+    f = gzip.open(filename, 'rt')
+    o = gzip.open("/datadrive/tmp.tsv.gz", 'wt')
+    final_line = ""
+    for i, line in enumerate(f):
+        if line[-1] == '\n':
+            line = line[:-1]
+        z = re.match("^[a-z][a-z]-[a-z][a-z]/[a-z][a-z]", line)
+        if not z:
+            final_line = final_line + line
+        else:
+            if i > 0:
+                o.write(final_line+'\n')
+            final_line = line
+    o.write(final_line+'\n')
+    f.close()
+    o.close()
+    copyfile("/datadrive/tmp.tsv.gz", filename)
+    os.remove("/datadrive/tmp.tsv.gz")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="fix the files")
+    parser.add_argument('--filename', type=str)
+    args = parser.parse_args()
+    fix(args.filename)


### PR DESCRIPTION
-------------------------------------------------------
Temporary files were being written when the directory didn't exist, so added mkdirs

The language pairs were checking the "raw" directory instead of the "split" directory, and wasn't appending them to the list of
pair_dirs, so fixed that.

The sort_files function was trying to use linux sort -n on zipped files, so I unzip them