### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ be found in [6], together with an extensive experimental evaluation.
 * [jieba 0.39](https://pypi.org/project/jieba/), Chinese segmenter (`pip install jieba`)
 * [mecab 0.996](https://pypi.org/project/JapaneseTokenizer/), Japanese segmenter
 * tokenization from the Moses encoder (installed automatically)
-* [FastBPE](https://github.com/glample/fastBPE), fast C++ implementation of byte-pair encoding (installed automatically)
+* [FastBPE](https://github.com/glample/fastBPE), fast C++ implementation of byte-pair encoding (installed automatically, but requires Cython `pip install cython`)
 
 ## Installation
 * set the environment variable 'LASER' to the root of the installation, e.g.


### PR DESCRIPTION
Cython is a dependency for fastBPE which is not automatically called from the setup.py script of fastBPE