### PR TITLE
Docker: add conda-forge channel to avoid PackagesNotFoundError

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM continuumio/miniconda3
 
 MAINTAINER Gilles Bodart <gillesbodart@users.noreply.github.com>
 
+RUN conda config --append channels conda-forge
 RUN conda create -n env python=3.6
 RUN echo "source activate env" > ~/.bashrc
 ENV PATH /opt/conda/envs/env/bin:$PATH


### PR DESCRIPTION
Got the following error on `docker build`:
```
#5 2.257 PackagesNotFoundError: The following packages are not available from current channels:
#5 2.257
#5 2.257   - python=3.6
```

After adding the conda-forge channel, was able to create a python 3.6 env.