### PR TITLE
add padded indices in max_token count in embed.py

### DIFF
--- a/source/embed.py
+++ b/source/embed.py
@@ -158,18 +158,22 @@ class SentenceEncoder:
 
         batch_tokens, batch_lengths, batch_indices = [], [], []
         ntokens = nsentences = 0
+        num_tokens_padded = -1
         for i in indices:
+            if num_tokens_padded == -1:
+                num_tokens_padded = tokens[i].shape[0]
             if nsentences > 0 and (
-                (self.max_tokens is not None and ntokens + lengths[i] > self.max_tokens)
+                (self.max_tokens is not None and ntokens + num_tokens_padded > self.max_tokens)
                 or (self.max_sentences is not None and nsentences == self.max_sentences)
             ):
                 yield batch(batch_tokens, batch_lengths, batch_indices)
                 ntokens = nsentences = 0
                 batch_tokens, batch_lengths, batch_indices = [], [], []
+                num_tokens_padded = -1
             batch_tokens.append(tokens[i])
             batch_lengths.append(lengths[i])
             batch_indices.append(i)
-            ntokens += tokens[i].shape[0]
+            ntokens += num_tokens_padded
             nsentences += 1
         if nsentences > 0:
             yield batch(batch_tokens, batch_lengths, batch_indices)


### PR DESCRIPTION
The origin implementation does not accurately get the number of tokens in batches, since it does not take into account of the padded tokens in token count, which is fixed in the PR.