### PR TITLE
Handle Interrupted Model Weight Downloads

### DIFF
--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -47,7 +47,6 @@ class LaserModelDownloader:
 
     def download(self, filename: str):
         url = os.path.join(self.base_url, filename)
-
         local_file_path = os.path.join(self.model_dir, filename)
 
         if os.path.exists(local_file_path):

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -48,7 +48,7 @@ class LaserModelDownloader:
         url = os.path.join(self.base_url, filename)
 
         local_file_path = os.path.join(self.model_dir, filename)
-        temp_file_path = os.path.join('/tmp', filename)
+        temp_file_path = os.path.join("/tmp", filename)
 
         if os.path.exists(local_file_path):
             logger.info(f" - {filename} already downloaded")
@@ -61,7 +61,7 @@ class LaserModelDownloader:
             response = requests.get(url, stream=True)
             total_size = int(response.headers.get("Content-Length", 0))
             progress_bar = tqdm(total=total_size, unit_scale=True, unit="B")
-            
+
             # Download to /tmp first
             with open(temp_file_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=1024):

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -46,20 +46,30 @@ class LaserModelDownloader:
 
     def download(self, filename: str):
         url = os.path.join(self.base_url, filename)
-        local_file_path = self.model_dir / filename
 
-        if local_file_path.exists():
+        local_file_path = os.path.join(self.model_dir, filename)
+        temp_file_path = os.path.join('/tmp', filename)
+
+        if os.path.exists(local_file_path):
             logger.info(f" - {filename} already downloaded")
         else:
             logger.info(f" - Downloading {filename}")
+
+            if os.path.exists(temp_file_path):
+                os.remove(temp_file_path)
+
             response = requests.get(url, stream=True)
             total_size = int(response.headers.get("Content-Length", 0))
             progress_bar = tqdm(total=total_size, unit_scale=True, unit="B")
-            with open(local_file_path, "wb") as f:
+            
+            # Download to /tmp first
+            with open(temp_file_path, "wb") as f:
                 for chunk in response.iter_content(chunk_size=1024):
                     f.write(chunk)
                     progress_bar.update(len(chunk))
             progress_bar.close()
+
+            os.rename(temp_file_path, local_file_path)
 
     def get_language_code(self, language_list: dict, lang: str) -> str:
         try:

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -67,7 +68,7 @@ class LaserModelDownloader:
                     progress_bar.update(len(chunk))
                 progress_bar.close()
 
-            os.rename(temp_file_path, local_file_path)
+            shutil.move(temp_file_path, local_file_path)
 
     def get_language_code(self, language_list: dict, lang: str) -> str:
         try:


### PR DESCRIPTION
## Description:
**Issue**: Interrupted downloads leave corrupted files in `~/.cache/laser_encoders` causing errors during model loading.

<img width="889" alt="Screenshot 2023-10-08 at 11 46 23" src="https://github.com/facebookresearch/LASER/assets/47500103/b3de6d9c-1347-4d36-8c6c-9ed84e6136b5">




**Fix**:
- Download model weights into the `/tmp` directory first.
- Move the complete download to the desired location.