### PR TITLE
Refactor `initialize_encoder` to `LaserEncoderPipeline`

### DIFF
--- a/laser_encoders/README.md
+++ b/laser_encoders/README.md
@@ -25,10 +25,21 @@ You can install laser_encoders using pip:
 
 ## Usage
 
-Here's a simple example of how you can download and initialise the tokenizer and encoder with just one step.
+Here's a simple example on how to obtain embeddings for sentences using the `LaserEncoderPipeline`:
 
-**Note:** By default, the models will be downloaded to the `~/.cache/laser_encoders` directory. To specify a different download location, you can provide the argument `model_dir=path/to/model/directory` to the initialize_tokenizer and initialize_encoder functions
+>**Note:** By default, the models will be downloaded to the `~/.cache/laser_encoders` directory. To specify a different download location, you can provide the argument `model_dir=path/to/model/directory`
 
+```py
+from laser_encoders import LaserEncoderPipeline
+
+# Initialize the LASER encoder pipeline
+encoder = LaserEncoderPipeline(lang="igbo")
+
+# Encode sentences into embeddings
+embeddings = encoder.encode_sentences(["nnọọ, kedu ka ị mere"])
+```
+
+If you prefer more control over the tokenization and encoding process, you can initialize the tokenizer and encoder separately:
 ```py
 from laser_encoders import initialize_encoder, initialize_tokenizer
 
@@ -39,16 +50,10 @@ tokenized_sentence = tokenizer.tokenize("nnọọ, kedu ka ị mere")
 # Initialize the LASER sentence encoder
 encoder = initialize_encoder(lang="igbo")
 
-# Encode sentences into embeddings
+# Encode tokenized sentences into embeddings
 embeddings = encoder.encode_sentences([tokenized_sentence])
 ```
-
-When initializing the encoder, you have the option to enable both tokenization and encoding by setting the `tokenize` flag to `True`. Below is an example of how to use it:
-```py
-encoder = initialize_encoder(lang="igbo", spm=True, tokenize=True)
-embeddings = encoder("nnọọ, kedu ka ị mere")
-```
->setting the `spm` flag to `True` tells the encoder to also download the accompanying spm model
+>By default, the `spm` flag is set to `True` when initializing the encoder, ensuring the accompanying spm model is downloaded.
 
 **Supported Languages:** You can specify any language from the [FLORES200](https://github.com/facebookresearch/flores/blob/main/flores200/README.md#languages-in-flores-200) dataset. This includes both languages identified by their full codes (like "ibo_Latn") and simpler alternatives (like "igbo").
 

--- a/laser_encoders/__init__.py
+++ b/laser_encoders/__init__.py
@@ -12,8 +12,5 @@
 #
 # -------------------------------------------------------
 
-from laser_encoders.download_models import (
-    LaserEncoderPipeline,
-    initialize_encoder,
-    initialize_tokenizer,
-)
+from laser_encoders.laser_tokenizer import initialize_tokenizer
+from laser_encoders.models import LaserEncoderPipeline, initialize_encoder

--- a/laser_encoders/__init__.py
+++ b/laser_encoders/__init__.py
@@ -12,4 +12,8 @@
 #
 # -------------------------------------------------------
 
-from laser_encoders.download_models import initialize_encoder, initialize_tokenizer
+from laser_encoders.download_models import (
+    LaserEncoderPipeline,
+    initialize_encoder,
+    initialize_tokenizer,
+)

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -160,10 +160,8 @@ def initialize_encoder(
     if not os.path.exists(spm_vocab):
         # if there is no cvocab for the laser3 lang use laser2 cvocab
         spm_vocab = os.path.join(model_dir, "laser2.cvocab")
-    
-    return SentenceEncoder(
-        model_path=model_path, spm_vocab=spm_vocab, spm_model=None
-    )
+
+    return SentenceEncoder(model_path=model_path, spm_vocab=spm_vocab, spm_model=None)
 
 
 def initialize_tokenizer(lang: str = None, model_dir: str = None, laser: str = None):
@@ -199,23 +197,31 @@ def initialize_tokenizer(lang: str = None, model_dir: str = None, laser: str = N
 
 
 class LaserEncoderPipeline:
-    def __init__(self, lang: str, model_dir: str = None, spm: bool = True, laser: str = None):
+    def __init__(
+        self, lang: str, model_dir: str = None, spm: bool = True, laser: str = None
+    ):
+        self.tokenizer = initialize_tokenizer(
+            lang=lang, model_dir=model_dir, laser=laser
+        )
+        self.encoder = initialize_encoder(
+            lang=lang, model_dir=model_dir, spm=spm, laser=laser
+        )
 
-        self.tokenizer = initialize_tokenizer(lang=lang, model_dir=model_dir, laser=laser)
-        self.encoder = initialize_encoder(lang=lang, model_dir=model_dir, spm=spm,laser=laser)
-    
     def encode_sentences(self, sentences: list) -> list:
         """
         Tokenizes and encodes a list of sentences.
-        
+
         Args:
         - sentences (list of str): List of sentences to tokenize and encode.
 
         Returns:
         - List of embeddings for each sentence.
         """
-        tokenized_sentences = [self.tokenizer.tokenize(sentence) for sentence in sentences]
+        tokenized_sentences = [
+            self.tokenizer.tokenize(sentence) for sentence in sentences
+        ]
         return self.encoder.encode_sentences(tokenized_sentences)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="LASER: Download Laser models")

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -198,6 +198,25 @@ def initialize_tokenizer(lang: str = None, model_dir: str = None, laser: str = N
     return LaserTokenizer(spm_model=Path(model_path))
 
 
+class LaserEncoderPipeline:
+    def __init__(self, lang: str, model_dir: str = None, spm: bool = True, laser: str = None):
+
+        self.tokenizer = initialize_tokenizer(lang=lang, model_dir=model_dir, laser=laser)
+        self.encoder = initialize_encoder(lang=lang, model_dir=model_dir, spm=spm,laser=laser)
+    
+    def encode_sentences(self, sentences: list) -> list:
+        """
+        Tokenizes and encodes a list of sentences.
+        
+        Args:
+        - sentences (list of str): List of sentences to tokenize and encode.
+
+        Returns:
+        - List of embeddings for each sentence.
+        """
+        tokenized_sentences = [self.tokenizer.tokenize(sentence) for sentence in sentences]
+        return self.encoder.encode_sentences(tokenized_sentences)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="LASER: Download Laser models")
     parser.add_argument(

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -26,8 +26,6 @@ import requests
 from tqdm import tqdm
 
 from laser_encoders.language_list import LASER2_LANGUAGE, LASER3_LANGUAGE, SPM_LANGUAGE
-from laser_encoders.laser_tokenizer import LaserTokenizer
-from laser_encoders.models import SentenceEncoder
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -119,108 +117,6 @@ class LaserModelDownloader:
                 raise ValueError(
                     f"Unsupported language name: {args.lang}. Please specify a supported language name using --lang."
                 )
-
-
-def initialize_encoder(
-    lang: str = None,
-    model_dir: str = None,
-    spm: bool = True,
-    laser: str = None,
-):
-    downloader = LaserModelDownloader(model_dir)
-    if laser is not None:
-        if laser == "laser3":
-            lang = downloader.get_language_code(LASER3_LANGUAGE, lang)
-            downloader.download_laser3(lang=lang, spm=spm)
-            file_path = f"laser3-{lang}.v1"
-        elif laser == "laser2":
-            downloader.download_laser2()
-            file_path = "laser2"
-        else:
-            raise ValueError(
-                f"Unsupported laser model: {laser}. Choose either laser2 or laser3."
-            )
-    else:
-        lang = downloader.get_language_code(LASER3_LANGUAGE, lang)
-        if lang in LASER3_LANGUAGE:
-            downloader.download_laser3(lang=lang, spm=spm)
-            file_path = f"laser3-{lang}.v1"
-        elif lang in LASER2_LANGUAGE:
-            downloader.download_laser2()
-            file_path = "laser2"
-        else:
-            raise ValueError(
-                f"Unsupported language name: {lang}. Please specify a supported language name."
-            )
-
-    model_dir = downloader.model_dir
-    model_path = os.path.join(model_dir, f"{file_path}.pt")
-    spm_vocab = os.path.join(model_dir, f"{file_path}.cvocab")
-
-    if not os.path.exists(spm_vocab):
-        # if there is no cvocab for the laser3 lang use laser2 cvocab
-        spm_vocab = os.path.join(model_dir, "laser2.cvocab")
-
-    return SentenceEncoder(model_path=model_path, spm_vocab=spm_vocab, spm_model=None)
-
-
-def initialize_tokenizer(lang: str = None, model_dir: str = None, laser: str = None):
-    downloader = LaserModelDownloader(model_dir)
-    if laser is not None:
-        if laser == "laser3":
-            lang = downloader.get_language_code(LASER3_LANGUAGE, lang)
-            if lang in SPM_LANGUAGE:
-                filename = f"laser3-{lang}.v1.spm"
-            else:
-                filename = "laser2.spm"
-        elif laser == "laser2":
-            filename = "laser2.spm"
-        else:
-            raise ValueError(
-                f"Unsupported laser model: {laser}. Choose either laser2 or laser3."
-            )
-    else:
-        if lang in LASER3_LANGUAGE or lang in LASER2_LANGUAGE:
-            lang = downloader.get_language_code(LASER3_LANGUAGE, lang)
-            if lang in SPM_LANGUAGE:
-                filename = f"laser3-{lang}.v1.spm"
-            else:
-                filename = "laser2.spm"
-        else:
-            raise ValueError(
-                f"Unsupported language name: {lang}. Please specify a supported language name."
-            )
-
-    downloader.download(filename)
-    model_path = os.path.join(downloader.model_dir, filename)
-    return LaserTokenizer(spm_model=Path(model_path))
-
-
-class LaserEncoderPipeline:
-    def __init__(
-        self, lang: str, model_dir: str = None, spm: bool = True, laser: str = None
-    ):
-        self.tokenizer = initialize_tokenizer(
-            lang=lang, model_dir=model_dir, laser=laser
-        )
-        self.encoder = initialize_encoder(
-            lang=lang, model_dir=model_dir, spm=spm, laser=laser
-        )
-
-    def encode_sentences(self, sentences: list) -> list:
-        """
-        Tokenizes and encodes a list of sentences.
-
-        Args:
-        - sentences (list of str): List of sentences to tokenize and encode.
-
-        Returns:
-        - List of embeddings for each sentence.
-        """
-        tokenized_sentences = [
-            self.tokenizer.tokenize(sentence) for sentence in sentences
-        ]
-        return self.encoder.encode_sentences(tokenized_sentences)
 
 
 if __name__ == "__main__":

--- a/laser_encoders/download_models.py
+++ b/laser_encoders/download_models.py
@@ -126,7 +126,6 @@ def initialize_encoder(
     model_dir: str = None,
     spm: bool = True,
     laser: str = None,
-    tokenize: bool = False,
 ):
     downloader = LaserModelDownloader(model_dir)
     if laser is not None:
@@ -157,17 +156,13 @@ def initialize_encoder(
     model_dir = downloader.model_dir
     model_path = os.path.join(model_dir, f"{file_path}.pt")
     spm_vocab = os.path.join(model_dir, f"{file_path}.cvocab")
-    spm_model = None
+
     if not os.path.exists(spm_vocab):
         # if there is no cvocab for the laser3 lang use laser2 cvocab
         spm_vocab = os.path.join(model_dir, "laser2.cvocab")
-    if tokenize:
-        spm_model = os.path.join(model_dir, f"{file_path}.spm")
-        if not os.path.exists(spm_model):
-            spm_model = os.path.join(model_dir, "laser2.spm")
-
+    
     return SentenceEncoder(
-        model_path=model_path, spm_vocab=spm_vocab, spm_model=spm_model
+        model_path=model_path, spm_vocab=spm_vocab, spm_model=None
     )
 
 

--- a/laser_encoders/models.py
+++ b/laser_encoders/models.py
@@ -329,6 +329,7 @@ class LaserLstmEncoder(nn.Module):
             else None,
         }
 
+
 def initialize_encoder(
     lang: str = None,
     model_dir: str = None,

--- a/laser_encoders/models.py
+++ b/laser_encoders/models.py
@@ -14,6 +14,7 @@
 
 
 import logging
+import os
 import re
 import sys
 from collections import namedtuple
@@ -26,7 +27,9 @@ from fairseq.data.dictionary import Dictionary
 from fairseq.models.transformer import Embedding, TransformerEncoder
 from fairseq.modules import LayerNorm
 
-from laser_encoders.laser_tokenizer import LaserTokenizer
+from laser_encoders.download_models import LaserModelDownloader
+from laser_encoders.language_list import LASER2_LANGUAGE, LASER3_LANGUAGE
+from laser_encoders.laser_tokenizer import LaserTokenizer, initialize_tokenizer
 
 SPACE_NORMALIZER = re.compile(r"\s+")
 Batch = namedtuple("Batch", "srcs tokens lengths")
@@ -325,3 +328,72 @@ class LaserLstmEncoder(nn.Module):
             if encoder_padding_mask.any()
             else None,
         }
+
+def initialize_encoder(
+    lang: str = None,
+    model_dir: str = None,
+    spm: bool = True,
+    laser: str = None,
+):
+    downloader = LaserModelDownloader(model_dir)
+    if laser is not None:
+        if laser == "laser3":
+            lang = downloader.get_language_code(LASER3_LANGUAGE, lang)
+            downloader.download_laser3(lang=lang, spm=spm)
+            file_path = f"laser3-{lang}.v1"
+        elif laser == "laser2":
+            downloader.download_laser2()
+            file_path = "laser2"
+        else:
+            raise ValueError(
+                f"Unsupported laser model: {laser}. Choose either laser2 or laser3."
+            )
+    else:
+        lang = downloader.get_language_code(LASER3_LANGUAGE, lang)
+        if lang in LASER3_LANGUAGE:
+            downloader.download_laser3(lang=lang, spm=spm)
+            file_path = f"laser3-{lang}.v1"
+        elif lang in LASER2_LANGUAGE:
+            downloader.download_laser2()
+            file_path = "laser2"
+        else:
+            raise ValueError(
+                f"Unsupported language name: {lang}. Please specify a supported language name."
+            )
+
+    model_dir = downloader.model_dir
+    model_path = os.path.join(model_dir, f"{file_path}.pt")
+    spm_vocab = os.path.join(model_dir, f"{file_path}.cvocab")
+
+    if not os.path.exists(spm_vocab):
+        # if there is no cvocab for the laser3 lang use laser2 cvocab
+        spm_vocab = os.path.join(model_dir, "laser2.cvocab")
+
+    return SentenceEncoder(model_path=model_path, spm_vocab=spm_vocab, spm_model=None)
+
+
+class LaserEncoderPipeline:
+    def __init__(
+        self, lang: str, model_dir: str = None, spm: bool = True, laser: str = None
+    ):
+        self.tokenizer = initialize_tokenizer(
+            lang=lang, model_dir=model_dir, laser=laser
+        )
+        self.encoder = initialize_encoder(
+            lang=lang, model_dir=model_dir, spm=spm, laser=laser
+        )
+
+    def encode_sentences(self, sentences: list) -> list:
+        """
+        Tokenizes and encodes a list of sentences.
+
+        Args:
+        - sentences (list of str): List of sentences to tokenize and encode.
+
+        Returns:
+        - List of embeddings for each sentence.
+        """
+        tokenized_sentences = [
+            self.tokenizer.tokenize(sentence) for sentence in sentences
+        ]
+        return self.encoder.encode_sentences(tokenized_sentences)


### PR DESCRIPTION
Description of this PR
- Changed `initialize_encoder` to `LaserEncoderPipeline` as suggested [here](https://github.com/facebookresearch/LASER/pull/249#discussion_r1362188779).
- Set `tokenize` to True by default to improve readability.
- Updated the README to reflect these changes, providing updated usage examples.