### PR TITLE
Enhance LaserTokenizer with Perl Parity, Optional Punctuation Normalization, and Embedding Normalization

### DIFF
--- a/laser_encoders/README.md
+++ b/laser_encoders/README.md
@@ -37,6 +37,9 @@ encoder = LaserEncoderPipeline(lang="igbo")
 
 # Encode sentences into embeddings
 embeddings = encoder.encode_sentences(["nnọọ, kedu ka ị mere"])
+# If you want the output embeddings to be L2-normalized, set normalize_embeddings to True
+normalized_embeddings = encoder.encode_sentences(["nnọọ, kedu ka ị mere"], normalize_embeddings=True)
+
 ```
 
 If you prefer more control over the tokenization and encoding process, you can initialize the tokenizer and encoder separately:

--- a/laser_encoders/README.md
+++ b/laser_encoders/README.md
@@ -8,7 +8,7 @@ laser_encoders is the official Python package for the Facebook [LASER](https://g
 
 - Python `>= 3.8`
 - [PyTorch `>= 2.0`](http://pytorch.org/)
-- sacremoses `>=0.0.53`
+- sacremoses `>=0.1.0`
 - sentencepiece `>=0.1.99`
 - numpy `>=1.25.0`
 - fairseq `>=0.12.2`

--- a/laser_encoders/laser_tokenizer.py
+++ b/laser_encoders/laser_tokenizer.py
@@ -47,6 +47,7 @@ class LaserTokenizer:
         descape: bool = False,
         verbose: bool = False,
         over_write: bool = False,
+        normalize_punct: bool = True,
     ):
         self.spm_model = spm_model
         self.lang = lang
@@ -54,6 +55,7 @@ class LaserTokenizer:
         self.descape = descape
         self.verbose = verbose
         self.over_write = over_write
+        self.normalize_punct = normalize_punct
 
         assert spm_model.exists(), f"spm model file: {spm_model} does not exist"
         self.moses_punct_normalizer = MosesPunctNormalizer(self.lang, perl_parity=True)
@@ -74,7 +76,8 @@ class LaserTokenizer:
     def tokenize(self, text: str) -> str:
         # Preprocessing
         sentence_text = "".join(c for c in text if c.isprintable)
-        sentence_text = self.moses_punct_normalizer.normalize(sentence_text)
+        if self.normalize_punct:
+            sentence_text = self.moses_punct_normalizer.normalize(sentence_text)
         if self.descape:
             sentence_text = self.moses_detokenizer.unescape_xml(text=sentence_text)
         if self.lower_case:

--- a/laser_encoders/laser_tokenizer.py
+++ b/laser_encoders/laser_tokenizer.py
@@ -56,7 +56,7 @@ class LaserTokenizer:
         self.over_write = over_write
 
         assert spm_model.exists(), f"spm model file: {spm_model} does not exist"
-        self.moses_punct_normalizer = MosesPunctNormalizer(self.lang)
+        self.moses_punct_normalizer = MosesPunctNormalizer(self.lang, perl_parity=True)
         self.moses_detokenizer = MosesDetokenizer()
         self.spm_encoder = spm.SentencePieceProcessor(model_file=str(self.spm_model))
 

--- a/laser_encoders/models.py
+++ b/laser_encoders/models.py
@@ -167,13 +167,19 @@ class SentenceEncoder:
         if nsentences > 0:
             yield batch(batch_tokens, batch_lengths, batch_indices)
 
-    def encode_sentences(self, sentences):
+    def encode_sentences(self, sentences, normalize_embeddings=False):
         indices = []
         results = []
         for batch, batch_indices in self._make_batches(sentences):
             indices.extend(batch_indices)
-            results.append(self._process_batch(batch))
+            encoded_batch = self._process_batch(batch)
+            if normalize_embeddings:
+                # Perform L2 normalization on the embeddings
+                norms = np.linalg.norm(encoded_batch, axis=1, keepdims=True)
+                encoded_batch = encoded_batch / norms
+            results.append(encoded_batch)
         return np.vstack(results)[np.argsort(indices, kind=self.sort_kind)]
+
 
 
 class LaserTransformerEncoder(TransformerEncoder):
@@ -384,7 +390,7 @@ class LaserEncoderPipeline:
             lang=lang, model_dir=model_dir, spm=spm, laser=laser
         )
 
-    def encode_sentences(self, sentences: list) -> list:
+    def encode_sentences(self, sentences: list, normalize_embeddings: bool = False) -> list:
         """
         Tokenizes and encodes a list of sentences.
 
@@ -397,4 +403,4 @@ class LaserEncoderPipeline:
         tokenized_sentences = [
             self.tokenizer.tokenize(sentence) for sentence in sentences
         ]
-        return self.encoder.encode_sentences(tokenized_sentences)
+        return self.encoder.encode_sentences(tokenized_sentences, normalize_embeddings)

--- a/laser_encoders/models.py
+++ b/laser_encoders/models.py
@@ -181,7 +181,6 @@ class SentenceEncoder:
         return np.vstack(results)[np.argsort(indices, kind=self.sort_kind)]
 
 
-
 class LaserTransformerEncoder(TransformerEncoder):
     def __init__(self, state_dict, vocab_path):
         self.dictionary = Dictionary.load(vocab_path)
@@ -390,7 +389,9 @@ class LaserEncoderPipeline:
             lang=lang, model_dir=model_dir, spm=spm, laser=laser
         )
 
-    def encode_sentences(self, sentences: list, normalize_embeddings: bool = False) -> list:
+    def encode_sentences(
+        self, sentences: list, normalize_embeddings: bool = False
+    ) -> list:
         """
         Tokenizes and encodes a list of sentences.
 

--- a/laser_encoders/requirements.txt
+++ b/laser_encoders/requirements.txt
@@ -2,7 +2,7 @@ fairseq==0.12.2
 numpy==1.25.0
 pytest==7.4.0
 Requests==2.31.0
-sacremoses==0.0.53
+sacremoses==0.1.0
 sentencepiece==0.1.99
 torch==2.0.1
 tqdm==4.65.0

--- a/laser_encoders/test_laser_tokenizer.py
+++ b/laser_encoders/test_laser_tokenizer.py
@@ -233,3 +233,33 @@ def test_separate_initialization_and_encoding(
     assert isinstance(embeddings, np.ndarray)
     assert embeddings.shape == expected_embedding_shape
     assert np.allclose(expected_array, embeddings[:, :10], atol=1e-3)
+
+def test_encoder_normalization(tmp_path: Path, test_readme_params: dict):
+    lang = test_readme_params["lang"]
+    input_sentences = test_readme_params["input_sentences"]
+
+    encoder = LaserEncoderPipeline(model_dir=tmp_path, lang=lang)
+    normalized_embeddings = encoder.encode_sentences(input_sentences, normalize_embeddings=True)
+    norm = np.linalg.norm(normalized_embeddings[0])
+
+    assert np.allclose(norm, 1.0, atol=1e-3)
+
+def test_encoder_default_behaviour(tmp_path: Path, test_readme_params: dict):
+    lang = test_readme_params["lang"]
+    input_sentences = test_readme_params["input_sentences"]
+
+    encoder = LaserEncoderPipeline(model_dir=tmp_path, lang=lang)
+    default_embeddings = encoder.encode_sentences(input_sentences)
+    non_normalized_embeddings = encoder.encode_sentences(input_sentences, normalize_embeddings=False)
+
+    assert np.allclose(default_embeddings, non_normalized_embeddings)
+
+def test_encoder_non_normalization(tmp_path: Path, test_readme_params: dict):
+    lang = test_readme_params["lang"]
+    input_sentences = test_readme_params["input_sentences"]
+
+    encoder = LaserEncoderPipeline(model_dir=tmp_path, lang=lang)
+    non_normalized_embeddings = encoder.encode_sentences(input_sentences, normalize_embeddings=False)
+    norm = np.linalg.norm(non_normalized_embeddings[0])
+
+    assert not np.isclose(norm, 1)

--- a/laser_encoders/test_laser_tokenizer.py
+++ b/laser_encoders/test_laser_tokenizer.py
@@ -234,15 +234,19 @@ def test_separate_initialization_and_encoding(
     assert embeddings.shape == expected_embedding_shape
     assert np.allclose(expected_array, embeddings[:, :10], atol=1e-3)
 
+
 def test_encoder_normalization(tmp_path: Path, test_readme_params: dict):
     lang = test_readme_params["lang"]
     input_sentences = test_readme_params["input_sentences"]
 
     encoder = LaserEncoderPipeline(model_dir=tmp_path, lang=lang)
-    normalized_embeddings = encoder.encode_sentences(input_sentences, normalize_embeddings=True)
+    normalized_embeddings = encoder.encode_sentences(
+        input_sentences, normalize_embeddings=True
+    )
     norm = np.linalg.norm(normalized_embeddings[0])
 
     assert np.allclose(norm, 1.0, atol=1e-3)
+
 
 def test_encoder_default_behaviour(tmp_path: Path, test_readme_params: dict):
     lang = test_readme_params["lang"]
@@ -250,16 +254,21 @@ def test_encoder_default_behaviour(tmp_path: Path, test_readme_params: dict):
 
     encoder = LaserEncoderPipeline(model_dir=tmp_path, lang=lang)
     default_embeddings = encoder.encode_sentences(input_sentences)
-    non_normalized_embeddings = encoder.encode_sentences(input_sentences, normalize_embeddings=False)
+    non_normalized_embeddings = encoder.encode_sentences(
+        input_sentences, normalize_embeddings=False
+    )
 
     assert np.allclose(default_embeddings, non_normalized_embeddings)
+
 
 def test_encoder_non_normalization(tmp_path: Path, test_readme_params: dict):
     lang = test_readme_params["lang"]
     input_sentences = test_readme_params["input_sentences"]
 
     encoder = LaserEncoderPipeline(model_dir=tmp_path, lang=lang)
-    non_normalized_embeddings = encoder.encode_sentences(input_sentences, normalize_embeddings=False)
+    non_normalized_embeddings = encoder.encode_sentences(
+        input_sentences, normalize_embeddings=False
+    )
     norm = np.linalg.norm(non_normalized_embeddings[0])
 
     assert not np.isclose(norm, 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "laser_encoders/README.md"
 requires-python = ">=3.8"
 
 dependencies = [
-    'sacremoses>=0.0.53',
+    'sacremoses>=0.1.0',
     'sentencepiece>=0.1.99',
     'numpy>=1.24',
     'torch>=2.0.1',

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -3,6 +3,6 @@ sentence-splitter==1.4
 botok==0.8.8
 khmer-nltk==1.5
 LaoNLP==0.6
-sacremoses==0.0.43
+sacremoses==0.1.0
 xxhash==3.0.0
 emoji==1.7.0

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -15,7 +15,7 @@ setup(
         "botok==0.8.8",
         "khmer-nltk==1.5",
         "LaoNLP==0.6",
-        "sacremoses==0.0.43",
+        "sacremoses==0.1.0",
         "xxhash==3.0.0",
         "emoji==1.7.0",
     ],

--- a/utils/src/cleaner_splitter.py
+++ b/utils/src/cleaner_splitter.py
@@ -20,7 +20,7 @@ class SentenceSplitClean:
         self.splitter = get_split_algo(splitter_lang, split_algo=split_algo)
 
         # setup "moses" normalization
-        self.mpn = MosesPunctNormalizer(lang="en")  # TODO
+        self.mpn = MosesPunctNormalizer(lang="en", perl_parity=True)  # TODO
         self.replace_nonprint = non_printing_char_replacer(" ")
 
     def __call__(self, line):


### PR DESCRIPTION
Changes:
Addresses #260 and #261 by @avidale 

- Introduced pearl compatibility flag (`perl_parity=True`)
- Added constructor argument `normalize_punct` to `LaserTokenizer`, with the default value of `True`, and run punctuation normalization and nonprintable character removal only if it is True.
- Added `normalize_embeddings` option to `encode_sentences` which is `False` by default. If it is `True`, we L2-normalize the embeddings before returning them.
- Added tests to verify that embeddings are correctly L2-normalized when the flag is True and remain unchanged when it is False.
- Update README on some of the changes.
