### PR TITLE
Decrease versions of numpy and torch required by laser-encoders

### DIFF
--- a/laser_encoders/README.md
+++ b/laser_encoders/README.md
@@ -13,7 +13,7 @@ laser_encoders is the official Python package for the Facebook [LASER](https://g
 - numpy `>=1.21.3`
 - fairseq `>=0.12.2`
 
-You can find a full list of requirements [here](requirements.txt)
+You can find a full list of requirements [here](https://github.com/facebookresearch/LASER/blob/main/pyproject.toml)
 
 ## Installation
 

--- a/laser_encoders/README.md
+++ b/laser_encoders/README.md
@@ -7,10 +7,10 @@ laser_encoders is the official Python package for the Facebook [LASER](https://g
 ## Dependencies
 
 - Python `>= 3.8`
-- [PyTorch `>= 2.0`](http://pytorch.org/)
+- [PyTorch `>= 1.10.0`](http://pytorch.org/)
 - sacremoses `>=0.1.0`
 - sentencepiece `>=0.1.99`
-- numpy `>=1.25.0`
+- numpy `>=1.21.3`
 - fairseq `>=0.12.2`
 
 You can find a full list of requirements [here](requirements.txt)

--- a/laser_encoders/requirements.txt
+++ b/laser_encoders/requirements.txt
@@ -1,8 +1,8 @@
 fairseq==0.12.2
-numpy==1.25.0
+numpy==1.21.3
 pytest==7.4.0
 Requests==2.31.0
 sacremoses==0.1.0
 sentencepiece==0.1.99
-torch==2.0.1
+torch==1.10.0
 tqdm==4.65.0

--- a/laser_encoders/requirements.txt
+++ b/laser_encoders/requirements.txt
@@ -1,8 +1,0 @@
-fairseq==0.12.2
-numpy==1.21.3
-pytest==7.4.0
-Requests==2.31.0
-sacremoses==0.1.0
-sentencepiece==0.1.99
-torch==1.10.0
-tqdm==4.65.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ requires-python = ">=3.8"
 dependencies = [
     'sacremoses>=0.1.0',
     'sentencepiece>=0.1.99',
-    'numpy>=1.24',
-    'torch>=2.0.1',
+    'numpy>=1.21.3',
+    'torch>=1.10.0',
     'fairseq>=0.12.2',
 ]
 


### PR DESCRIPTION
## Changes

Addresses #263 by @avidale
- Update torch and numpy requirements to follow [fairseq](https://github.com/facebookresearch/fairseq)
- Run tests to make sure nothing breaks


![Screenshot 2023-11-15 at 02 54 58](https://github.com/facebookresearch/LASER/assets/47500103/d319afa4-1116-40b8-b86f-80d20a2307ce)
